### PR TITLE
Load Settings if Available and Fix Incorrect Installation Path

### DIFF
--- a/CP2077 - EasyInstall/FindGames.cs
+++ b/CP2077 - EasyInstall/FindGames.cs
@@ -1,18 +1,22 @@
-﻿using System;
-using Microsoft.Win32;
+﻿using Microsoft.Win32;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace SharpGameReg
+namespace CP2077___EasyInstall
 {
     class SteamGamePath
     {
+        /// <summary>
+        /// Get the install path for the Steam installation of Cyberpunk 2077.
+        /// </summary>
+        /// <returns>Windows Registry for Steam installtion location.</returns>
         static string GetSteamPath()
         {
-            return (string)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Valve\\Steam", "InstallPath", null);
+            return Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Valve\\Steam", "InstallPath", null).ToString();
         }
+
         static List<string> SteamLibraryPaths()
         {
             string libraryfoldersPath = GetSteamPath();
@@ -40,6 +44,7 @@ namespace SharpGameReg
             }
             return toReturn;
         }
+
         static string FindGameACFByAppID(string appID)
         {
             /* If we do not add this other games with the same number in 
@@ -59,6 +64,7 @@ namespace SharpGameReg
             }
             return null; // Game not installed or something is wrong.
         }
+
         // I split these up so it looks neater.
         public static string FindGameByAppID(string appID)
         {
@@ -80,17 +86,26 @@ namespace SharpGameReg
             }
             return null;
         }
+
         static string[] SplitByQuotes(string unsplitArray)
         {
             var re = new Regex("\"[^\"]*\"");
             return re.Matches(unsplitArray).Cast<Match>().Select(m => m.Value).ToArray(); // Split into an array using quotes to split
         }
     }
+
+    /// <summary>
+    /// Good Old Games installation location.
+    /// </summary>
     class GoGGamePath
     {
+        /// <summary>
+        /// Get the install path for the GoG installation of Cyberpunk 2077.
+        /// </summary>
+        /// <returns>Windows Registry for GoG installtion location.</returns>
         public static string FindGameByAppID(string appID)
         {
-            return (string)Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\GOG.com\\Games\\" + appID + "\\", "Path", null);
+            return Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\GOG.com\\Games\\" + appID + "\\", "Path", null).ToString();
         }
     }
 }

--- a/CP2077 - EasyInstall/Form1.cs
+++ b/CP2077 - EasyInstall/Form1.cs
@@ -5,7 +5,6 @@ using System.IO.Compression;
 using System.Net;
 using System.Windows.Forms;
 using Newtonsoft.Json;
-using SharpGameReg;
 
 namespace CP2077___EasyInstall
 {
@@ -428,7 +427,7 @@ namespace CP2077___EasyInstall
                 //DialogResult dialogResult = MessageBox.Show(path, "Is this Correct?", MessageBoxButtons.YesNo);
                 DialogResult result = MetroFramework.MetroMessageBox.Show(this, path, "Is this Correct?", MessageBoxButtons.YesNo);
                 if (result == DialogResult.Yes)
-                    PatchGame(path);
+                    PatchGame($"{path}\\bin\\x64");
                 else if (result == DialogResult.No)
                 {
                     MetroFramework.MetroMessageBox.Show(this, null, "Install Canceled.", MessageBoxButtons.OK);

--- a/CP2077 - EasyInstall/Form1.cs
+++ b/CP2077 - EasyInstall/Form1.cs
@@ -33,16 +33,36 @@ namespace CP2077___EasyInstall
                 btnMain.Enabled = false;
                 btnFindSteam.Enabled = false;
                 btnFindGoG.Enabled = false;
+
+                LoadSettings(generalPath);
 #if DEBUG
                 MessageBox.Show("Patch already installed!");
 #endif
             }
-            catch (Exception)
+            catch (Exception ex)
             {
 #if DEBUG
                 MessageBox.Show("Patch not already installed!");
 #endif
             }
+        }
+
+        private void LoadSettings(string generalPath)
+        {
+            var data = JsonConvert.DeserializeObject<Data>(File.ReadAllText($"{generalPath}\\plugins\\cyber_engine_tweaks\\config.json"));
+
+            cbAVX.Checked = data.AVX;
+            numCpuMem.Value = (decimal)data.CPUMemoryPoolFraction;
+            cbAntialiasing.Checked = data.DisableAntialiasing;
+            cbAsyncCompute.Checked = data.DisableAsyncCompute;
+            numGpuMem.Value = (decimal)data.GPUMemoryPoolFraction;
+            cbMemoryPool.Checked = data.MemoryPool;
+            cbRemovePedestrians.Checked = data.RemovePedestrians;
+            cbSkipStartMenu.Checked = data.SkipStartMenu;
+            cbSMT.Checked = data.SMT;
+            cbSpectre.Checked = data.Spectre;
+            cbDebug.Checked = data.UnlockMenu;
+            cbVInput.Checked = data.VirtualInput;
         }
 
         /// <summary>
@@ -109,7 +129,6 @@ namespace CP2077___EasyInstall
 
                 if (result == DialogResult.OK && !string.IsNullOrWhiteSpace(fbd.SelectedPath))
                 {
-
                     string gamePath = $"{fbd.SelectedPath}\\bin\\x64";
                     if (generalPath == string.Empty)
                     {
@@ -161,9 +180,9 @@ namespace CP2077___EasyInstall
                     MessageBox.Show($"game_path path = {localPath}");
 #endif
                     File.WriteAllText(localPath, gamePath);
+                    LoadSettings(gamePath);
 #if DEBUG
                     MessageBox.Show("Path correctly created!\n");
-
 #endif
                 }
                 catch (Exception)
@@ -381,18 +400,24 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                btnMain.Text = "Working ...";
+                btnMain.Text = "Working...";
                 string path = SteamGamePath.FindGameByAppID("1091500");
                 if (path == null)
                 {
-                    MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find CyberPunk for Steam!", "File not found Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find Cyberpunk for Steam!", "File not found Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     //MessageBox.Show("Error: Couldn't Find CyberPunk for steam!");
                     btnMain.Text = "Select Path to Cyberpunk 2077 Main Directory";
                     return;
                 }
                 DialogResult result = MessageBox.Show(path, "Is this Correct?", MessageBoxButtons.YesNo);
                 if (result == DialogResult.Yes)
-                    PatchGame(path);
+                {
+                    if (generalPath == string.Empty)
+                    {
+                        generalPath = $"{path}\\bin\\x64";
+                    }
+                    PatchGame($"{path}\\bin\\x64");
+                }
                 else if (result == DialogResult.No)
                 {
                     MetroFramework.MetroMessageBox.Show(this, null, "Install Canceled.", MessageBoxButtons.OK);
@@ -406,7 +431,7 @@ namespace CP2077___EasyInstall
             }
             catch (Exception ex)
             {
-                MetroFramework.MetroMessageBox.Show(this, "Error: " + ex, "Unknown Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MetroFramework.MetroMessageBox.Show(this, $"Error: {ex}", "Unknown Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 //MessageBox.Show("Error" + ex);
             }
         }
@@ -415,11 +440,11 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                btnMain.Text = "Working ...";
+                btnMain.Text = "Working...";
                 string path = GoGGamePath.FindGameByAppID("1423049311");
                 if (path == null)
                 {
-                    MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find CyberPunk for GoG!", "File not found Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find Cyberpunk for GoG!", "File not found Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     //MessageBox.Show("Error: Couldn't Find CyberPunk for GoG!");
                     btnMain.Text = "Select Path to Cyberpunk 2077 Main Directory";
                     return;
@@ -427,7 +452,13 @@ namespace CP2077___EasyInstall
                 //DialogResult dialogResult = MessageBox.Show(path, "Is this Correct?", MessageBoxButtons.YesNo);
                 DialogResult result = MetroFramework.MetroMessageBox.Show(this, path, "Is this Correct?", MessageBoxButtons.YesNo);
                 if (result == DialogResult.Yes)
+                {
+                    if (generalPath == string.Empty)
+                    {
+                        generalPath = $"{path}\\bin\\x64";
+                    }
                     PatchGame($"{path}\\bin\\x64");
+                }
                 else if (result == DialogResult.No)
                 {
                     MetroFramework.MetroMessageBox.Show(this, null, "Install Canceled.", MessageBoxButtons.OK);
@@ -441,7 +472,7 @@ namespace CP2077___EasyInstall
             }
             catch (Exception ex)
             {
-                MetroFramework.MetroMessageBox.Show(this, "Error: " + ex, "Unknown Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MetroFramework.MetroMessageBox.Show(this, $"Error: {ex}", "Unknown Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 //MessageBox.Show("Error" + ex);
             }
         }

--- a/CP2077 - EasyInstall/Properties/AssemblyInfo.cs
+++ b/CP2077 - EasyInstall/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyFileVersion("2.3.0.0")]


### PR DESCRIPTION
**Load Settings from config.json:** Makes sense to load in the user's preferred settings when launching the application for a second time, so now the settings are loaded on startup and options are set.

**Fixed Incorrect Installation Path:** The auto-find option would only install into the root of the game folder, rather than the `\bin\x64` folder. This has been fixed. Issue noted from #6.