### PR TITLE
Support for 1.0.0

### DIFF
--- a/CP2077 - EasyInstall/Form1.Designer.cs
+++ b/CP2077 - EasyInstall/Form1.Designer.cs
@@ -33,6 +33,7 @@ namespace CP2077___EasyInstall
             this.btnMain = new MetroFramework.Controls.MetroButton();
             this.btnAbout = new MetroFramework.Controls.MetroLink();
             this.gbxSettings = new System.Windows.Forms.GroupBox();
+            this.cbConsole = new MetroFramework.Controls.MetroCheckBox();
             this.cbAntialiasing = new MetroFramework.Controls.MetroCheckBox();
             this.cbSkipStartMenu = new MetroFramework.Controls.MetroCheckBox();
             this.cbRemovePedestrians = new MetroFramework.Controls.MetroCheckBox();
@@ -72,6 +73,7 @@ namespace CP2077___EasyInstall
             this.btnFindSteam = new MetroFramework.Controls.MetroButton();
             this.tt_steam = new MetroFramework.Components.MetroToolTip();
             this.tt_gog = new MetroFramework.Components.MetroToolTip();
+            this.ttEnableConsole = new MetroFramework.Components.MetroToolTip();
             this.gbxSettings.SuspendLayout();
             this.gbxMemPool.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numGpuMem)).BeginInit();
@@ -93,7 +95,7 @@ namespace CP2077___EasyInstall
             // 
             // btnAbout
             // 
-            this.btnAbout.Location = new System.Drawing.Point(180, 519);
+            this.btnAbout.Location = new System.Drawing.Point(180, 557);
             this.btnAbout.Name = "btnAbout";
             this.btnAbout.Size = new System.Drawing.Size(72, 15);
             this.btnAbout.TabIndex = 25;
@@ -103,6 +105,7 @@ namespace CP2077___EasyInstall
             // 
             // gbxSettings
             // 
+            this.gbxSettings.Controls.Add(this.cbConsole);
             this.gbxSettings.Controls.Add(this.cbAntialiasing);
             this.gbxSettings.Controls.Add(this.cbSkipStartMenu);
             this.gbxSettings.Controls.Add(this.cbRemovePedestrians);
@@ -116,10 +119,24 @@ namespace CP2077___EasyInstall
             this.gbxSettings.Controls.Add(this.cbAVX);
             this.gbxSettings.Location = new System.Drawing.Point(24, 141);
             this.gbxSettings.Name = "gbxSettings";
-            this.gbxSettings.Size = new System.Drawing.Size(388, 174);
+            this.gbxSettings.Size = new System.Drawing.Size(388, 213);
             this.gbxSettings.TabIndex = 3;
             this.gbxSettings.TabStop = false;
             this.gbxSettings.Text = "Settings:";
+            // 
+            // cbConsole
+            // 
+            this.cbConsole.AutoSize = true;
+            this.cbConsole.Checked = true;
+            this.cbConsole.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.cbConsole.FontSize = MetroFramework.MetroCheckBoxSize.Medium;
+            this.cbConsole.Location = new System.Drawing.Point(6, 171);
+            this.cbConsole.Name = "cbConsole";
+            this.cbConsole.Size = new System.Drawing.Size(118, 19);
+            this.cbConsole.TabIndex = 15;
+            this.cbConsole.Text = "Enable Console";
+            this.ttEnableConsole.SetToolTip(this.cbConsole, "Adds an overlay to draw whatever UI you want on top of the game.\nPress the 'End' key to toggle the console");
+            this.cbConsole.UseSelectable = true;
             // 
             // cbAntialiasing
             // 
@@ -267,7 +284,7 @@ namespace CP2077___EasyInstall
             // 
             // btnUpdate
             // 
-            this.btnUpdate.Location = new System.Drawing.Point(22, 486);
+            this.btnUpdate.Location = new System.Drawing.Point(22, 524);
             this.btnUpdate.Name = "btnUpdate";
             this.btnUpdate.Size = new System.Drawing.Size(175, 23);
             this.btnUpdate.TabIndex = 23;
@@ -278,7 +295,7 @@ namespace CP2077___EasyInstall
             // 
             // btnSettings
             // 
-            this.btnSettings.Location = new System.Drawing.Point(22, 449);
+            this.btnSettings.Location = new System.Drawing.Point(22, 487);
             this.btnSettings.Name = "btnSettings";
             this.btnSettings.Size = new System.Drawing.Size(390, 31);
             this.btnSettings.TabIndex = 22;
@@ -289,7 +306,7 @@ namespace CP2077___EasyInstall
             // 
             // btnSave
             // 
-            this.btnSave.Location = new System.Drawing.Point(22, 375);
+            this.btnSave.Location = new System.Drawing.Point(22, 413);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(390, 31);
             this.btnSave.TabIndex = 20;
@@ -384,7 +401,7 @@ namespace CP2077___EasyInstall
             // 
             // btnLogs
             // 
-            this.btnLogs.Location = new System.Drawing.Point(22, 412);
+            this.btnLogs.Location = new System.Drawing.Point(22, 450);
             this.btnLogs.Name = "btnLogs";
             this.btnLogs.Size = new System.Drawing.Size(390, 31);
             this.btnLogs.TabIndex = 21;
@@ -398,7 +415,7 @@ namespace CP2077___EasyInstall
             this.gbxMemPool.Controls.Add(this.numCpuMem);
             this.gbxMemPool.Controls.Add(this.lblGpuMem);
             this.gbxMemPool.Controls.Add(this.lblCpuMem);
-            this.gbxMemPool.Location = new System.Drawing.Point(24, 322);
+            this.gbxMemPool.Location = new System.Drawing.Point(24, 360);
             this.gbxMemPool.Name = "gbxMemPool";
             this.gbxMemPool.Size = new System.Drawing.Size(388, 47);
             this.gbxMemPool.TabIndex = 15;
@@ -471,7 +488,7 @@ namespace CP2077___EasyInstall
             // 
             // btnUninstall
             // 
-            this.btnUninstall.Location = new System.Drawing.Point(237, 486);
+            this.btnUninstall.Location = new System.Drawing.Point(237, 524);
             this.btnUninstall.Name = "btnUninstall";
             this.btnUninstall.Size = new System.Drawing.Size(175, 23);
             this.btnUninstall.TabIndex = 24;
@@ -515,11 +532,17 @@ namespace CP2077___EasyInstall
             this.tt_gog.StyleManager = null;
             this.tt_gog.Theme = MetroFramework.MetroThemeStyle.Light;
             // 
+            // ttEnableConsole
+            // 
+            this.ttEnableConsole.Style = MetroFramework.MetroColorStyle.Blue;
+            this.ttEnableConsole.StyleManager = null;
+            this.ttEnableConsole.Theme = MetroFramework.MetroThemeStyle.Light;
+            // 
             // Form1
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(435, 543);
+            this.ClientSize = new System.Drawing.Size(435, 589);
             this.Controls.Add(this.btnFindGoG);
             this.Controls.Add(this.btnFindSteam);
             this.Controls.Add(this.btnUninstall);
@@ -592,6 +615,8 @@ namespace CP2077___EasyInstall
         private MetroFramework.Controls.MetroButton btnFindSteam;
         private MetroFramework.Components.MetroToolTip tt_gog;
         private MetroFramework.Components.MetroToolTip tt_steam;
+        private MetroFramework.Controls.MetroCheckBox cbConsole;
+        private MetroFramework.Components.MetroToolTip ttEnableConsole;
     }
 }
 

--- a/CP2077 - EasyInstall/Form1.cs
+++ b/CP2077 - EasyInstall/Form1.cs
@@ -22,34 +22,34 @@ namespace CP2077___EasyInstall
             try
             {
                 // Check if the patch is already installed. If game_path file != NULL == already installed.
-                var localPath = $"{Directory.GetCurrentDirectory()}\\game_path";
+                var localPath = $@"{Directory.GetCurrentDirectory()}\game_path";
 
                 string myPath = File.ReadAllText(localPath);
 #if DEBUG
-                MessageBox.Show(myPath);
+                Trace.WriteLine(myPath);
 #endif
                 generalPath = myPath;
-                btnMain.Text = "Patch Already Installed!";
+                btnMain.Text = "Patch already installed!";
                 btnMain.Enabled = false;
                 btnFindSteam.Enabled = false;
                 btnFindGoG.Enabled = false;
 
                 LoadSettings(generalPath);
 #if DEBUG
-                MessageBox.Show("Patch already installed!");
+                Trace.WriteLine("Patch already installed!");
 #endif
             }
-            catch (Exception ex)
+            catch (Exception)
             {
 #if DEBUG
-                MessageBox.Show("Patch not already installed!");
+                Trace.WriteLine("Patch not already installed!");
 #endif
             }
         }
 
         private void LoadSettings(string generalPath)
         {
-            var data = JsonConvert.DeserializeObject<Data>(File.ReadAllText($"{generalPath}\\plugins\\cyber_engine_tweaks\\config.json"));
+            var data = JsonConvert.DeserializeObject<Data>(File.ReadAllText($@"{generalPath}\plugins\cyber_engine_tweaks\config.json"));
 
             cbAVX.Checked = data.AVX;
             numCpuMem.Value = (decimal)data.CPUMemoryPoolFraction;
@@ -102,7 +102,7 @@ namespace CP2077___EasyInstall
             foreach (FileInfo fi in source.GetFiles())
             {
 #if DEBUG
-                MessageBox.Show($"Copying {target.FullName}\\{fi.Name}");
+                Trace.WriteLine($@"Copying {target.FullName}\{fi.Name}");
 #endif
                 fi.CopyTo(Path.Combine(target.FullName, fi.Name), true);
             }
@@ -129,7 +129,7 @@ namespace CP2077___EasyInstall
 
                 if (result == DialogResult.OK && !string.IsNullOrWhiteSpace(fbd.SelectedPath))
                 {
-                    string gamePath = $"{fbd.SelectedPath}\\bin\\x64";
+                    string gamePath = $@"{fbd.SelectedPath}\bin\x64";
                     if (generalPath == string.Empty)
                     {
                         generalPath = gamePath;
@@ -156,7 +156,7 @@ namespace CP2077___EasyInstall
         private void PatchGame(string gamePath)
         {
 #if DEBUG
-            MessageBox.Show($"Path Selected: {gamePath}", "Message");
+            Trace.WriteLine($"Path Selected: {gamePath}", "Message");
 #endif
             try
             {
@@ -173,36 +173,31 @@ namespace CP2077___EasyInstall
                 }
 
                 // Write Path file. It is used for checking if the patch has already been installed (on next restart)
-                try
-                {
-                    var localPath = $"{Directory.GetCurrentDirectory()}\\game_path";
+                var localPath = $"{Directory.GetCurrentDirectory()}\\game_path";
 #if DEBUG
-                    MessageBox.Show($"game_path path = {localPath}");
+                Trace.WriteLine($"game_path path = {localPath}");
 #endif
-                    File.WriteAllText(localPath, gamePath);
-                    LoadSettings(gamePath);
+                File.WriteAllText(localPath, gamePath);
+                LoadSettings(gamePath);
 #if DEBUG
-                    MessageBox.Show("Path correctly created!\n");
+                Trace.WriteLine("Path correctly created!\n");
 #endif
-                }
-                catch (Exception)
-                {
-                    MessageBox.Show("Patch successfully installed, but I wasn't able to create <game_path> file for correctly detect the position!");
-                }
-                try // Remove the Release.zip after extraction
-                {
-                    string remove_ReleaseZip = $"{Directory.GetCurrentDirectory()}\\Release.zip";
-                    File.Delete(remove_ReleaseZip);
-                }
-                catch (IOException ex)
-                {
-                    MetroFramework.MetroMessageBox.Show(this, $"Error during installation\nError code: 1\n{ex.InnerException}", "Critical Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
+                // Remove the Release.zip and Release folder after extraction.
+                string removeReleaseZip = $@"{Directory.GetCurrentDirectory()}\Release.zip";
+                string downloadPath = $@"{Directory.GetCurrentDirectory()}\Patch";
+
+                File.Delete(removeReleaseZip);
+                Directory.Delete(downloadPath, true);
+
                 MetroFramework.MetroMessageBox.Show(this, "Patch successfully installed!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Question);
                 btnMain.Text = "Successfully Installed!";
                 btnMain.Enabled = false;
                 btnFindSteam.Enabled = false;
                 btnFindGoG.Enabled = false;
+            }
+            catch (IOException ex)
+            {
+                MetroFramework.MetroMessageBox.Show(this, $"Error during installation\nError code: 1\n{ex.InnerException}", "Critical Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             catch (Exception ex)
             {
@@ -228,7 +223,7 @@ namespace CP2077___EasyInstall
         /// <param name="e"></param>
         private void btnSave_Click(object sender, EventArgs e)
         {
-            string settingsPath = $"{generalPath}\\plugins\\cyber_engine_tweaks\\config.json";
+            string settingsPath = $@"{generalPath}\plugins\cyber_engine_tweaks\config.json";
 
             bool avxSet = cbAVX.Checked;
             bool smtSet = cbSMT.Checked;
@@ -277,7 +272,7 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                string settingsPath = $"{generalPath}\\plugins\\cyber_engine_tweaks\\config.json";
+                string settingsPath = $@"{generalPath}\plugins\cyber_engine_tweaks\config.json";
                 Process.Start(settingsPath);
             }
             catch (Exception)
@@ -293,21 +288,24 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                string DownloadPath = $"{Directory.GetCurrentDirectory()}\\Patch";
-                FileStream zipFile = File.Create($"{Directory.GetCurrentDirectory()}\\Release.zip");
+                string downloadPath = $@"{Directory.GetCurrentDirectory()}\Patch";
+                string zipDownloadFile = $@"{Directory.GetCurrentDirectory()}\Release.zip";
+
+                FileStream zipFile = File.Create(zipDownloadFile);
                 zipFile.Close();
+
                 btnMain.Text = "Downloading";
 
                 using (var httpclient = new WebClient())
                 {
-                    httpclient.DownloadFile("https://github.com/yamashi/PerformanceOverhaulCyberpunk/releases/latest/download/Release.zip", $"{Directory.GetCurrentDirectory()}\\Release.zip");
+                    httpclient.DownloadFile("https://github.com/yamashi/PerformanceOverhaulCyberpunk/releases/latest/download/Release.zip", zipDownloadFile);
                 }
 
-                if (Directory.Exists(DownloadPath))
-                    Directory.Delete(DownloadPath, true);
+                if (Directory.Exists(downloadPath))
+                    Directory.Delete(downloadPath, true);
 
                 btnMain.Text = "Extracting";
-                ZipFile.ExtractToDirectory($"{Directory.GetCurrentDirectory()}\\Release.zip", DownloadPath);
+                ZipFile.ExtractToDirectory(zipDownloadFile, downloadPath);
             }
             catch (IOException ex)
             {
@@ -330,13 +328,13 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                string path = File.ReadAllText($"{Directory.GetCurrentDirectory()}\\game_path");
+                string path = File.ReadAllText($@"{Directory.GetCurrentDirectory()}\game_path");
                 PatchGame(path);
                 btnMain.Text = "Successfully Installed";
             }
             catch (Exception)
             {
-                MetroFramework.MetroMessageBox.Show(this, "Select Cyberpunk 2077 Main Folder, before check for updates!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MetroFramework.MetroMessageBox.Show(this, "Pleaes select Cyberpunk 2077 main folder before checking for updates!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
         }
 
@@ -347,14 +345,14 @@ namespace CP2077___EasyInstall
         /// <param name="e"></param>
         private void btnLogs_Click(object sender, EventArgs e)
         {
-            string settingsPath = $"{generalPath}\\plugins\\cyber_engine_tweaks\\cyber_engine_tweaks.log";
+            string settingsPath = $@"{generalPath}\plugins\cyber_engine_tweaks\cyber_engine_tweaks.log";
             try
             {
                 Process.Start(settingsPath);
             }
             catch (Exception)
             {
-                MetroFramework.MetroMessageBox.Show(this, "File not found, you need to run the game at least one time, before generate log file!\nError code: 4", "Exception!", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MetroFramework.MetroMessageBox.Show(this, "File not found, you need to run the game at least one time before a log file can be generated!\nError code: 4", "Exception!", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -368,11 +366,11 @@ namespace CP2077___EasyInstall
             try
             {
                 // version.dll file path
-                string versionDLL = $"{generalPath}\\version.dll";
+                string versionDLL = $@"{generalPath}\version.dll";
                 // plugins folder path 
-                string mypath = $"{generalPath}\\plugins";
+                string mypath = $@"{generalPath}\plugins";
                 // game_path file path
-                string game_path = $"{Directory.GetCurrentDirectory()}\\game_path";
+                string game_path = $@"{Directory.GetCurrentDirectory()}\game_path";
 
                 // Delete plugins directory recursively
                 Directory.Delete(mypath, true);
@@ -393,7 +391,7 @@ namespace CP2077___EasyInstall
             }
             catch (Exception)
             {
-                MetroFramework.MetroMessageBox.Show(this, "Uninstall was not able to delete the mod. Just delete <cyberpunk install path>/bin/x64/version.dll and <cyberpunk install path>/bin/x64/plugins/", "Exception!", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                MetroFramework.MetroMessageBox.Show(this, $"Unable to delete mod files.\nPlease remove {generalPath}\\version.dll and {generalPath}\\plugins\\ manually.", "Exception!", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
         private void btnFindSteam_Click(object sender, EventArgs e)
@@ -405,18 +403,19 @@ namespace CP2077___EasyInstall
                 if (path == null)
                 {
                     MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find Cyberpunk for Steam!", "File not found Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    //MessageBox.Show("Error: Couldn't Find CyberPunk for steam!");
+                    //Trace.WriteLine("Error: Couldn't Find CyberPunk for steam!");
                     btnMain.Text = "Select Path to Cyberpunk 2077 Main Directory";
                     return;
                 }
-                DialogResult result = MessageBox.Show(path, "Is this Correct?", MessageBoxButtons.YesNo);
+
+                DialogResult result = MetroFramework.MetroMessageBox.Show(this, path, "Is this Correct?", MessageBoxButtons.YesNo);
                 if (result == DialogResult.Yes)
                 {
                     if (generalPath == string.Empty)
                     {
-                        generalPath = $"{path}\\bin\\x64";
+                        generalPath = $@"{path}\bin\x64";
                     }
-                    PatchGame($"{path}\\bin\\x64");
+                    PatchGame($@"{path}\bin\x64");
                 }
                 else if (result == DialogResult.No)
                 {
@@ -432,7 +431,7 @@ namespace CP2077___EasyInstall
             catch (Exception ex)
             {
                 MetroFramework.MetroMessageBox.Show(this, $"Error: {ex}", "Unknown Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                //MessageBox.Show("Error" + ex);
+                //Trace.WriteLine("Error" + ex);
             }
         }
 
@@ -445,19 +444,19 @@ namespace CP2077___EasyInstall
                 if (path == null)
                 {
                     MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find Cyberpunk for GoG!", "File not found Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    //MessageBox.Show("Error: Couldn't Find CyberPunk for GoG!");
+                    //Trace.WriteLine("Error: Couldn't Find CyberPunk for GoG!");
                     btnMain.Text = "Select Path to Cyberpunk 2077 Main Directory";
                     return;
                 }
-                //DialogResult dialogResult = MessageBox.Show(path, "Is this Correct?", MessageBoxButtons.YesNo);
+
                 DialogResult result = MetroFramework.MetroMessageBox.Show(this, path, "Is this Correct?", MessageBoxButtons.YesNo);
                 if (result == DialogResult.Yes)
                 {
                     if (generalPath == string.Empty)
                     {
-                        generalPath = $"{path}\\bin\\x64";
+                        generalPath = $@"{path}\bin\x64";
                     }
-                    PatchGame($"{path}\\bin\\x64");
+                    PatchGame($@"{path}\bin\x64");
                 }
                 else if (result == DialogResult.No)
                 {
@@ -473,7 +472,7 @@ namespace CP2077___EasyInstall
             catch (Exception ex)
             {
                 MetroFramework.MetroMessageBox.Show(this, $"Error: {ex}", "Unknown Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                //MessageBox.Show("Error" + ex);
+                //Trace.WriteLine("Error" + ex);
             }
         }
     }

--- a/CP2077 - EasyInstall/Form1.cs
+++ b/CP2077 - EasyInstall/Form1.cs
@@ -63,6 +63,8 @@ namespace CP2077___EasyInstall
             cbSpectre.Checked = data.Spectre;
             cbDebug.Checked = data.UnlockMenu;
             cbVInput.Checked = data.VirtualInput;
+            cbVInput.Checked = data.VirtualInput;
+            cbConsole.Checked = data.Console;
         }
 
         /// <summary>
@@ -225,33 +227,21 @@ namespace CP2077___EasyInstall
         {
             string settingsPath = $@"{generalPath}\plugins\cyber_engine_tweaks\config.json";
 
-            bool avxSet = cbAVX.Checked;
-            bool smtSet = cbSMT.Checked;
-            bool memorySet = cbMemoryPool.Checked;
-            bool spectreSet = cbSpectre.Checked;
-            bool debugSet = cbDebug.Checked;
-            bool vInputSet = cbVInput.Checked;
-            bool asyncCompute = cbAsyncCompute.Checked;
-            bool removePedestrians = cbRemovePedestrians.Checked;
-            bool skipStartMenu = cbSkipStartMenu.Checked;
-            bool antialiasing = cbAntialiasing.Checked;
-            double CpuMem = (double)numCpuMem.Value;
-            double GpuMem = (double)numGpuMem.Value;
-
             var data = new Data()
             {
-                AVX = avxSet,
-                SMT = smtSet,
-                Spectre = spectreSet,
-                VirtualInput = vInputSet,
-                MemoryPool = memorySet,
-                UnlockMenu = debugSet,
-                CPUMemoryPoolFraction = CpuMem,
-                GPUMemoryPoolFraction = GpuMem,
-                RemovePedestrians = removePedestrians,
-                SkipStartMenu = skipStartMenu,
-                DisableAsyncCompute = asyncCompute,
-                DisableAntialiasing = antialiasing
+                AVX = cbAVX.Checked,
+                SMT = cbSMT.Checked,
+                Spectre = cbMemoryPool.Checked,
+                VirtualInput = cbSpectre.Checked,
+                MemoryPool = cbMemoryPool.Checked,
+                UnlockMenu = cbDebug.Checked,
+                CPUMemoryPoolFraction = (double)numCpuMem.Value,
+                GPUMemoryPoolFraction = (double)numGpuMem.Value,
+                RemovePedestrians = cbRemovePedestrians.Checked,
+                SkipStartMenu = cbSkipStartMenu.Checked,
+                DisableAsyncCompute = cbAsyncCompute.Checked,
+                DisableAntialiasing = cbAntialiasing.Checked,
+                Console = cbConsole.Checked
             };
 
             using (StreamWriter file = File.CreateText(settingsPath))

--- a/CP2077 - EasyInstall/Form1.resx
+++ b/CP2077 - EasyInstall/Form1.resx
@@ -120,11 +120,11 @@
   <metadata name="tt_selectPath.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>329, 17</value>
   </metadata>
-  <metadata name="tt_aliasing.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>244, 56</value>
-  </metadata>
   <metadata name="tt_skip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>817, 17</value>
+  </metadata>
+  <metadata name="tt_aliasing.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>244, 56</value>
   </metadata>
   <metadata name="tt_pedestrians.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>116, 56</value>
@@ -164,6 +164,12 @@
   </metadata>
   <metadata name="tt_steam.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>350, 56</value>
+  </metadata>
+  <metadata name="ttEnableConsole.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>535, 56</value>
+  </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>104</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/CP2077 - EasyInstall/data.cs
+++ b/CP2077 - EasyInstall/data.cs
@@ -39,5 +39,8 @@ namespace CP2077___EasyInstall
 
         [JsonProperty("disable_antialiasing")]
         public bool DisableAntialiasing { get; set; }
+
+        [JsonProperty("console")]
+        public bool Console { get; set; }
     }
 }


### PR DESCRIPTION
**Support for 1.0.0:** Added support for the Enable Console command.

**More code cleanup:** Was in the middle of fixing it up when version 1.0.0 dropped, but I have enough done that I'm happy for the time being. Turns out you can use string interpolation and verbatim strings at the same time, so that cleans up some of the path listings. Removed additional variables that were a little bit pointless.

**Changed Diag Boxes for Debugging:** Moved debug boxes to Traces so messages will now appear in the Output window. Makes it a little more tolerable when debugging :P.