### PR TITLE
Get rid of Windows paths + better code maintainability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+#end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true
+
+[*.{json,yml,md}]
+indent_size = 2

--- a/CP2077 - EasyInstall.sln
+++ b/CP2077 - EasyInstall.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 16.0.30717.126
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CP2077 - EasyInstall", "CP2077 - EasyInstall\CP2077 - EasyInstall.csproj", "{78C08192-D7C9-4762-8D05-0FE2EDDB7EA7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E5B4230E-2D8F-4301-AB0E-B6650E3B1AD6}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/CP2077 - EasyInstall/App.config
+++ b/CP2077 - EasyInstall/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
-    <startup> 
+    <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
 </configuration>

--- a/CP2077 - EasyInstall/FindGames.cs
+++ b/CP2077 - EasyInstall/FindGames.cs
@@ -53,7 +53,7 @@ namespace CP2077___EasyInstall
              * its name can be returned instead.
              * ex - Try 730 (cs:go) and have 976730 (MCC) installed.
              * If we find MCC first we return that instead of csgo.
-             * All appID in steam file start with _ and ends with .acf.
+             * All appID in Steam file start with _ and ends with .acf.
              */
             appID = $"_{appID}.acf";
             foreach (var path in SteamLibraryPaths())

--- a/CP2077 - EasyInstall/FindGames.cs
+++ b/CP2077 - EasyInstall/FindGames.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Win32;
+using Microsoft.Win32;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/CP2077 - EasyInstall/FindGames.cs
+++ b/CP2077 - EasyInstall/FindGames.cs
@@ -14,7 +14,7 @@ namespace CP2077___EasyInstall
         /// <returns>Windows Registry for Steam installation location.</returns>
         private static string GetSteamPath()
         {
-            return Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\Valve\\Steam", "InstallPath", null)?.ToString();
+            return Registry.GetValue(@"HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Valve\Steam", "InstallPath", null)?.ToString();
         }
 
         private static List<string> SteamLibraryPaths()
@@ -26,7 +26,7 @@ namespace CP2077___EasyInstall
             {
                 libraryfoldersPath // By default steam install path is a steam library location
             };
-            libraryfoldersPath += "\\steamapps\\libraryfolders.vdf"; // This file holds al paths
+            libraryfoldersPath = Path.Combine(libraryfoldersPath, "steamapps", "libraryfolders.vdf"); // This file holds all paths
             string unsortedPaths = string.Empty;
             using (StreamReader sr = File.OpenText(libraryfoldersPath))
             {
@@ -55,11 +55,11 @@ namespace CP2077___EasyInstall
              * If we find MCC first we return that instead of csgo.
              * All appID in steam file start with _ and ends with .acf.
              */
-            appID = "_" + appID + ".acf";
+            appID = $"_{appID}.acf";
             foreach (var path in SteamLibraryPaths())
             {
-                string steamappPath = path + "\\steamapps\\"; // ACF files are in steamapp folder
-                var filesInPath = Directory.GetFiles(steamappPath);
+                // ACF files are in steamapps folder
+                var filesInPath = Directory.GetFiles(Path.Combine(path, "steamapps"));
                 foreach (var file in filesInPath)
                     if (file.Contains(appID)) // If we find the appID we can stop looking
                         return file;
@@ -83,7 +83,7 @@ namespace CP2077___EasyInstall
                         /* Instead of refinding the whole file path again I just remove the .acf file
                          * and add on common and the installdir.
                          */
-                        return ACFFile.Substring(0, ACFFile.LastIndexOf("\\") + 1) + "common\\" + currentLineArr[1].Trim('\"') /*+ "\\"*/;
+                        return $@"{ACFFile.Substring(0, ACFFile.LastIndexOf(@"\") + 1)}common\{currentLineArr[1].Trim('\"')}";
                     }
             }
             return null;
@@ -102,12 +102,12 @@ namespace CP2077___EasyInstall
     internal class GoGGamePath
     {
         /// <summary>
-        /// Get the install path for the GoG installation of Cyberpunk 2077.
+        /// Get the install path for the GOG installation of Cyberpunk 2077.
         /// </summary>
-        /// <returns>Windows Registry for GoG installtion location.</returns>
+        /// <returns>Windows Registry for GOG installation location.</returns>
         public static string FindGameByAppID(string appID)
         {
-            return Registry.GetValue("HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\GOG.com\\Games\\" + appID + "\\", "Path", null)?.ToString();
+            return Registry.GetValue($@"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\GOG.com\Games\{appID}\", "Path", null)?.ToString();
         }
     }
 }

--- a/CP2077 - EasyInstall/Form1.Designer.cs
+++ b/CP2077 - EasyInstall/Form1.Designer.cs
@@ -295,7 +295,7 @@
             this.cbAVX.TabIndex = 5;
             this.cbAVX.Tag = "";
             this.cbAVX.Text = "AVX";
-            this.tt_avx.SetToolTip(this.cbAVX, " Fixes a crash when playing the game with a CPU that does not support AVX");
+            this.tt_avx.SetToolTip(this.cbAVX, "Fixes a crash when playing the game with a CPU that does not support AVX");
             this.cbAVX.UseSelectable = true;
             // 
             // btnUpdate
@@ -569,7 +569,7 @@
             this.lblUpdate.Name = "lblUpdate";
             this.lblUpdate.Size = new System.Drawing.Size(266, 15);
             this.lblUpdate.TabIndex = 26;
-            this.lblUpdate.Text = "You are currently running the lastest version available";
+            this.lblUpdate.Text = "You are currently running the latest version available";
             this.lblUpdate.Click += new System.EventHandler(this.lblUpdate_Click);
             // 
             // Form1

--- a/CP2077 - EasyInstall/Form1.Designer.cs
+++ b/CP2077 - EasyInstall/Form1.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace CP2077___EasyInstall
+namespace CP2077___EasyInstall
 {
     partial class Form1
     {

--- a/CP2077 - EasyInstall/Form1.cs
+++ b/CP2077 - EasyInstall/Form1.cs
@@ -450,7 +450,7 @@ namespace CP2077___EasyInstall
                 if (path == null)
                 {
                     MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find Cyberpunk for Steam!", "File not found Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    //TraceDebugWrite("Error: Couldn't Find CyberPunk for steam!");
+                    //TraceDebugWrite("Error: Couldn't Find CyberPunk for Steam!");
                     btnMain.Text = "Select Path to Cyberpunk 2077 Main Directory";
                     return;
                 }

--- a/CP2077 - EasyInstall/Form1.cs
+++ b/CP2077 - EasyInstall/Form1.cs
@@ -1,17 +1,20 @@
-﻿using System;
+using Newtonsoft.Json;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Net;
 using System.Windows.Forms;
-using Newtonsoft.Json;
 
 namespace CP2077___EasyInstall
 {
     public partial class Form1 : MetroFramework.Forms.MetroForm
     {
-        string generalPath = string.Empty; // Main x64 path.
-        string remoteUrlVersion = "https://pastebin.com/raw/uTz51FZw";
+        private string generalPath = string.Empty; // Main x64 path.
+        private const string RemoteUrlVersion = "https://pastebin.com/raw/uTz51FZw";
+
+        private static readonly string CurrentDir = Directory.GetCurrentDirectory();
+        private static readonly string GamePathFilePath = Path.Combine(CurrentDir, "game_path");
 
         /// <summary>
         /// Entry point for the application
@@ -34,7 +37,7 @@ namespace CP2077___EasyInstall
                 }
                 else
                 {
-                    lblUpdate.Text = "Update available, click me for download it !";
+                    lblUpdate.Text = "Update available, click me for download it!";
                     //lblUpdate.Foreground = System.Drawing.Color.Green;
                 }
             }
@@ -42,12 +45,9 @@ namespace CP2077___EasyInstall
             try
             {
                 // Check if the patch is already installed. If game_path file != NULL == already installed.
-                var localPath = $@"{Directory.GetCurrentDirectory()}\game_path";
+                string myPath = File.ReadAllText(GamePathFilePath);
+                TraceDebugWrite(myPath);
 
-                string myPath = File.ReadAllText(localPath);
-#if DEBUG
-                Trace.WriteLine(myPath);
-#endif
                 generalPath = myPath;
                 btnMain.Text = "Patch already installed!";
                 btnMain.Enabled = false;
@@ -55,77 +55,70 @@ namespace CP2077___EasyInstall
                 btnFindGoG.Enabled = false;
 
                 LoadSettings(generalPath);
-#if DEBUG
-                Trace.WriteLine("Patch already installed!");
-#endif
+                TraceDebugWrite("Patch already installed!");
             }
             catch (Exception)
             {
-#if DEBUG
-                Trace.WriteLine("Patch not already installed!");
-#endif
+                TraceDebugWrite("Patch not already installed!");
             }
         }
 
-        private int LocalVer ()
+        private static int LocalVer()
         {
-            int localver = 0, 
-            counter = 0;  
+            int localver = 0,
+            counter = 0;
 
-            string line, 
+            string line,
                    string_version;
 
-            var VersionPath = $@"{Directory.GetCurrentDirectory()}\version";
+            var versionPath = Path.Combine(CurrentDir, "version");
             try
             {
-                System.IO.StreamReader file = new System.IO.StreamReader(VersionPath); //get local version by <version> file
+                StreamReader file = new StreamReader(versionPath); //get local version by <version> file
                 while ((line = file.ReadLine()) != null && counter < 1)
                 {
                     counter++;
                     string_version = line;
-                    localver = Int32.Parse(string_version);
-#if DEBUG
-                    Trace.WriteLine("Local version =" + localver);
-#endif
+                    localver = int.Parse(string_version);
+                    TraceDebugWrite($"Local version = {localver}");
                 }
                 file.Close();
             }
-            catch (Exception) 
+            catch (Exception)
             {
                 MessageBox.Show("Error while getting local version\nContact support please!", "Critical Error", MessageBoxButtons.OK, MessageBoxIcon.Stop); // error message
             }
-            return (localver); //ritorna la versione locale
+            return localver;
         }
-        
-        private int RemoteVer ()
+
+        private static int RemoteVer ()
         {
-            int remotever = 0; // result of this function 
+            int remotever = 0; // result of this function
             string raw_version; // raw version before the parse
 
             try
             {
-                HttpWebRequest request = HttpWebRequest.CreateHttp(remoteUrlVersion);
+                HttpWebRequest request = WebRequest.CreateHttp(RemoteUrlVersion);
                 string responseBodyFromRemoteServer; //server response
                 using (HttpWebResponse response = (HttpWebResponse)request.GetResponse())
-
                 using (StreamReader reader = new StreamReader(response.GetResponseStream()))
+                {
                     responseBodyFromRemoteServer = reader.ReadToEnd();
-                raw_version = responseBodyFromRemoteServer.ToString();
-                remotever = Int32.Parse(raw_version);
-#if DEBUG
-                Trace.WriteLine("Remote version =" + remotever);
-#endif
+                }
+                raw_version = responseBodyFromRemoteServer;
+                remotever = int.Parse(raw_version);
+                TraceDebugWrite($"Remote version = {remotever}");
             }
             catch (Exception)
             {
                 MessageBox.Show("http error, remote version not found!\nCheck the main repository for updates!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning); // error message
             }
-            return (remotever);
+            return remotever;
         }
 
         private void LoadSettings(string generalPath)
         {
-            var data = JsonConvert.DeserializeObject<Data>(File.ReadAllText($@"{generalPath}\plugins\cyber_engine_tweaks\config.json"));
+            var data = JsonConvert.DeserializeObject<Data>(File.ReadAllText(Path.Combine(generalPath, "plugins", "cyber_engine_tweaks", "config.json")));
 
             cbAVX.Checked = data.AVX;
             numCpuMem.Value = (decimal)data.CPUMemoryPoolFraction;
@@ -180,9 +173,7 @@ namespace CP2077___EasyInstall
             // Copy each file into the new directory.
             foreach (FileInfo fi in source.GetFiles())
             {
-#if DEBUG
-                Trace.WriteLine($@"Copying {target.FullName}\{fi.Name}");
-#endif
+                TraceDebugWrite($@"Copying {target.FullName}\{fi.Name}");
                 fi.CopyTo(Path.Combine(target.FullName, fi.Name), true);
             }
 
@@ -208,8 +199,8 @@ namespace CP2077___EasyInstall
 
                 if (result == DialogResult.OK && !string.IsNullOrWhiteSpace(fbd.SelectedPath))
                 {
-                    string gamePath = $@"{fbd.SelectedPath}\bin\x64";
-                    if (generalPath == string.Empty)
+                    string gamePath = Path.Combine(fbd.SelectedPath, "bin", "x64");
+                    if (string.IsNullOrWhiteSpace(generalPath))
                     {
                         generalPath = gamePath;
                     }
@@ -234,9 +225,8 @@ namespace CP2077___EasyInstall
         /// <param name="gamePath">Location of the game files.</param>
         private void PatchGame(string gamePath)
         {
-#if DEBUG
-            Trace.WriteLine($"Path Selected: {gamePath}", "Message");
-#endif
+            TraceDebugWrite($"Path Selected: {gamePath}", "Message");
+
             try
             {
                 DownloadLatestVersion();
@@ -245,25 +235,22 @@ namespace CP2077___EasyInstall
                 string targetDirectory = gamePath;
                 Copy("Patch", targetDirectory);
 
-                string docPath = Directory.GetCurrentDirectory();
-                using (StreamWriter outputFile = new StreamWriter(Path.Combine(docPath, "game_path")))
+                using (StreamWriter outputFile = new StreamWriter(GamePathFilePath))
                 {
                     outputFile.Write(gamePath);
                 }
 
+                TraceDebugWrite($"game_path path = {GamePathFilePath}");
+
                 // Write Path file. It is used for checking if the patch has already been installed (on next restart)
-                var localPath = $"{Directory.GetCurrentDirectory()}\\game_path";
-#if DEBUG
-                Trace.WriteLine($"game_path path = {localPath}");
-#endif
-                File.WriteAllText(localPath, gamePath);
+                File.WriteAllText(GamePathFilePath, gamePath);
                 LoadSettings(gamePath);
-#if DEBUG
-                Trace.WriteLine("Path correctly created!\n");
-#endif
+
+                TraceDebugWrite("Path correctly created!\n");
+
                 // Remove the Release.zip and Release folder after extraction.
-                string removeReleaseZip = $@"{Directory.GetCurrentDirectory()}\Release.zip";
-                string downloadPath = $@"{Directory.GetCurrentDirectory()}\Patch";
+                string removeReleaseZip = Path.Combine(CurrentDir, "Release.zip");
+                string downloadPath = Path.Combine(CurrentDir, "Patch");
 
                 File.Delete(removeReleaseZip);
                 Directory.Delete(downloadPath, true);
@@ -302,7 +289,7 @@ namespace CP2077___EasyInstall
         /// <param name="e"></param>
         private void btnSave_Click(object sender, EventArgs e)
         {
-            string settingsPath = $@"{generalPath}\plugins\cyber_engine_tweaks\config.json";
+            string settingsPath = Path.Combine(generalPath, "plugins", "cyber_engine_tweaks", "config.json");
 
             var data = new Data()
             {
@@ -340,7 +327,7 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                string settingsPath = $@"{generalPath}\plugins\cyber_engine_tweaks\config.json";
+                string settingsPath = Path.Combine(generalPath, "plugins", "cyber_engine_tweaks", "config.json");
                 Process.Start(settingsPath);
             }
             catch (Exception)
@@ -356,8 +343,8 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                string downloadPath = $@"{Directory.GetCurrentDirectory()}\Patch";
-                string zipDownloadFile = $@"{Directory.GetCurrentDirectory()}\Release.zip";
+                string downloadPath = Path.Combine(CurrentDir, "Patch");
+                string zipDownloadFile = Path.Combine(CurrentDir, "Release.zip");
 
                 FileStream zipFile = File.Create(zipDownloadFile);
                 zipFile.Close();
@@ -396,13 +383,12 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                string path = File.ReadAllText($@"{Directory.GetCurrentDirectory()}\game_path");
-                PatchGame(path);
+                PatchGame(File.ReadAllText(GamePathFilePath));
                 btnMain.Text = "Successfully Installed";
             }
             catch (Exception)
             {
-                MetroFramework.MetroMessageBox.Show(this, "Pleaes select Cyberpunk 2077 main folder before checking for updates!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                MetroFramework.MetroMessageBox.Show(this, "Please select Cyberpunk 2077 main folder before checking for updates!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
         }
 
@@ -413,10 +399,10 @@ namespace CP2077___EasyInstall
         /// <param name="e"></param>
         private void btnLogs_Click(object sender, EventArgs e)
         {
-            string settingsPath = $@"{generalPath}\plugins\cyber_engine_tweaks\cyber_engine_tweaks.log";
+            string logPath = Path.Combine(generalPath, "plugins", "cyber_engine_tweaks", "cyber_engine_tweaks.log");
             try
             {
-                Process.Start(settingsPath);
+                Process.Start(logPath);
             }
             catch (Exception)
             {
@@ -433,23 +419,16 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                // version.dll file path
-                string versionDLL = $@"{generalPath}\version.dll";
-                // plugins folder path 
-                string mypath = $@"{generalPath}\plugins";
-                // game_path file path
-                string game_path = $@"{Directory.GetCurrentDirectory()}\game_path";
-
                 // Delete plugins directory recursively
-                Directory.Delete(mypath, true);
+                Directory.Delete(Path.Combine(generalPath, "plugins"), true);
 
                 // Delete version.dll file
-                File.Delete(versionDLL);
+                File.Delete(Path.Combine(generalPath, "version.dll"));
 
                 // Delete game_path file
-                File.Delete(game_path);
+                File.Delete(GamePathFilePath);
 
-                // Unlock main_button for reinstall the patch 
+                // Unlock main_button for reinstall the patch
                 btnMain.Text = "Select Path To Cyberpunk 2077 Main Directory";
                 btnMain.Enabled = true;
                 btnFindSteam.Enabled = true;
@@ -471,7 +450,7 @@ namespace CP2077___EasyInstall
                 if (path == null)
                 {
                     MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find Cyberpunk for Steam!", "File not found Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    //Trace.WriteLine("Error: Couldn't Find CyberPunk for steam!");
+                    //TraceDebugWrite("Error: Couldn't Find CyberPunk for steam!");
                     btnMain.Text = "Select Path to Cyberpunk 2077 Main Directory";
                     return;
                 }
@@ -479,11 +458,11 @@ namespace CP2077___EasyInstall
                 DialogResult result = MetroFramework.MetroMessageBox.Show(this, path, "Is this Correct?", MessageBoxButtons.YesNo);
                 if (result == DialogResult.Yes)
                 {
-                    if (generalPath == string.Empty)
+                    if (string.IsNullOrWhiteSpace(generalPath))
                     {
-                        generalPath = $@"{path}\bin\x64";
+                        generalPath = Path.Combine(path, "bin", "x64");
                     }
-                    PatchGame($@"{path}\bin\x64");
+                    PatchGame(Path.Combine(path, "bin", "x64"));
                 }
                 else if (result == DialogResult.No)
                 {
@@ -499,7 +478,7 @@ namespace CP2077___EasyInstall
             catch (Exception ex)
             {
                 MetroFramework.MetroMessageBox.Show(this, $"Error: {ex}", "Unknown Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                //Trace.WriteLine("Error" + ex);
+                //TraceDebugWrite("Error" + ex);
             }
         }
 
@@ -511,8 +490,8 @@ namespace CP2077___EasyInstall
                 string path = GoGGamePath.FindGameByAppID("1423049311");
                 if (path == null)
                 {
-                    MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find Cyberpunk for GoG!", "File not found Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                    //Trace.WriteLine("Error: Couldn't Find CyberPunk for GoG!");
+                    MetroFramework.MetroMessageBox.Show(this, "Error: Couldn't Find Cyberpunk for GOG!", "Error: File not found!", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    //TraceDebugWrite("Error: Couldn't Find CyberPunk for GoG!");
                     btnMain.Text = "Select Path to Cyberpunk 2077 Main Directory";
                     return;
                 }
@@ -520,11 +499,11 @@ namespace CP2077___EasyInstall
                 DialogResult result = MetroFramework.MetroMessageBox.Show(this, path, "Is this Correct?", MessageBoxButtons.YesNo);
                 if (result == DialogResult.Yes)
                 {
-                    if (generalPath == string.Empty)
+                    if (string.IsNullOrWhiteSpace(generalPath))
                     {
-                        generalPath = $@"{path}\bin\x64";
+                        generalPath = Path.Combine(path, "bin", "x64");
                     }
-                    PatchGame($@"{path}\bin\x64");
+                    PatchGame(Path.Combine(path, "bin", "x64"));
                 }
                 else if (result == DialogResult.No)
                 {
@@ -540,21 +519,29 @@ namespace CP2077___EasyInstall
             catch (Exception ex)
             {
                 MetroFramework.MetroMessageBox.Show(this, $"Error: {ex}", "Unknown Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                //Trace.WriteLine("Error" + ex);
+                //TraceDebugWrite("Error" + ex);
             }
         }
 
         private void lblUpdate_Click(object sender, EventArgs e)
         {
-            if (lblUpdate.Text == "Update available, click me for download it !")
+            if (lblUpdate.Text == "Update available, click me for download it!")
             {
                 Process.Start("https://github.com/LittleZen/Cyberpunk2077-Patch-Easy-Installer/releases");
                 Environment.Exit(1);
             }
             else
             {
-                MetroFramework.MetroMessageBox.Show(this, "\nYou are running the lastest version!", "Update", MessageBoxButtons.OK, MessageBoxIcon.Question);
+                MetroFramework.MetroMessageBox.Show(this, "\nYou are running the latest version!", "Update", MessageBoxButtons.OK, MessageBoxIcon.Question);
             }
+        }
+
+        // TODO: Move to separate Logger class?
+        private static void TraceDebugWrite(string message, string category = null)
+        {
+            #if DEBUG
+                Trace.WriteLine(message, category);
+            #endif
         }
     }
 }

--- a/CP2077 - EasyInstall/Program.cs
+++ b/CP2077 - EasyInstall/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows.Forms;
 
 namespace CP2077___EasyInstall

--- a/CP2077 - EasyInstall/app.manifest
+++ b/CP2077 - EasyInstall/app.manifest
@@ -1,18 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
   <assemblyIdentity version="1.0.0.0" name="MyApplication.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
         <!-- UAC Manifest Options
-             If you want to change the Windows User Account Control level replace the 
+             If you want to change the Windows User Account Control level replace the
              requestedExecutionLevel node with one of the following.
 
         <requestedExecutionLevel  level="asInvoker" uiAccess="false" />
         <requestedExecutionLevel  level="requireAdministrator" uiAccess="false" />
         <requestedExecutionLevel  level="highestAvailable" uiAccess="false" />
 
-            Specifying requestedExecutionLevel element will disable file and registry virtualization. 
+            Specifying requestedExecutionLevel element will disable file and registry virtualization.
             Remove this element if your application requires this virtualization for backwards
             compatibility.
         -->
@@ -46,8 +46,8 @@
   </compatibility>
 
   <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
-       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
-       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should
        also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. -->
   <!--
   <application xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/CP2077 - EasyInstall/data.cs
+++ b/CP2077 - EasyInstall/data.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace CP2077___EasyInstall
 {

--- a/CP2077 - EasyInstall/packages.config
+++ b/CP2077 - EasyInstall/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MetroModernUI" version="1.4.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />


### PR DESCRIPTION
- Get rid of Windows paths (use `Path.Combine()`)
- Use string interpolations and verbatim strings
- Remove multiple `#if DEBUG` in `Form1.cs`
- Fix typos
- EditorConfig