### PR TITLE
Clean downloadPath folder 

### DIFF
--- a/CP2077 - EasyInstall/MainWindow.cs
+++ b/CP2077 - EasyInstall/MainWindow.cs
@@ -390,6 +390,11 @@ namespace CP2077___EasyInstall
 
         private static void CleanFolder(string folderPath)
         {
+            if (!Directory.Exists(folderPath))
+            {
+                return;
+            }
+
             var dirInfo = new DirectoryInfo(folderPath);
 
             foreach (var file in dirInfo.EnumerateFiles())

--- a/CP2077 - EasyInstall/MainWindow.cs
+++ b/CP2077 - EasyInstall/MainWindow.cs
@@ -370,6 +370,9 @@ namespace CP2077___EasyInstall
                     httpClient.DownloadFile($"https://github.com/yamashi/CyberEngineTweaks/releases/latest/download/{release}", zipDownloadFile);
                 }
 
+                // Clean downloadPath folder to prevent Exception while trying to extract already exists files
+                CleanFolder(downloadPath);
+
                 btnMain.Text = "Extracting...";
                 ZipFile.ExtractToDirectory(zipDownloadFile, downloadPath);
 
@@ -382,6 +385,21 @@ namespace CP2077___EasyInstall
                 MetroFramework.MetroMessageBox.Show(this, $"Error during downloading {ExceptionAsString(ex)}", "Critical Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 btnMain.Text = "Critical Error!";
                 DisableGbx(); //disable the settings page
+            }
+        }
+
+        private static void CleanFolder(string folderPath)
+        {
+            var dirInfo = new DirectoryInfo(folderPath);
+
+            foreach (var file in dirInfo.EnumerateFiles())
+            {
+                file.Delete();
+            }
+
+            foreach (var dir in dirInfo.EnumerateDirectories())
+            {
+                dir.Delete(true);
             }
         }
 

--- a/CP2077 - EasyInstall/MainWindow.cs
+++ b/CP2077 - EasyInstall/MainWindow.cs
@@ -377,8 +377,7 @@ namespace CP2077___EasyInstall
                 ZipFile.ExtractToDirectory(zipDownloadFile, downloadPath);
 
                 // Delete zip archive, after extract it to Patch Folder
-                if(File.Exists(zipDownloadFile))
-                   File.Delete(zipDownloadFile);
+                File.Delete(zipDownloadFile);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Clean downloadPath folder to prevent Exception while trying to extract already exists files