### PR TITLE
Usage of app.config for game path and mod versions

### DIFF
--- a/CP2077 - EasyInstall/App.config
+++ b/CP2077 - EasyInstall/App.config
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+    <appSettings />
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>

--- a/CP2077 - EasyInstall/CP2077 - EasyInstall.csproj
+++ b/CP2077 - EasyInstall/CP2077 - EasyInstall.csproj
@@ -85,6 +85,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GitHub.cs" />
     <Compile Include="UpdateUtil.cs" />
     <Compile Include="Data.cs" />
     <Compile Include="FindGames.cs" />

--- a/CP2077 - EasyInstall/CP2077 - EasyInstall.csproj
+++ b/CP2077 - EasyInstall/CP2077 - EasyInstall.csproj
@@ -67,13 +67,31 @@
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Configuration.ConfigurationManager, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Configuration.ConfigurationManager.5.0.0\lib\net461\System.Configuration.ConfigurationManager.dll</HintPath>
+    </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Data.OracleClient" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Security" />
+    <Reference Include="System.Security.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.AccessControl.5.0.0\lib\net461\System.Security.AccessControl.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Permissions, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Permissions.5.0.0\lib\net461\System.Security.Permissions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.5.0.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ServiceProcess" />
+    <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -83,6 +101,7 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GitHub.cs" />

--- a/CP2077 - EasyInstall/GitHub.cs
+++ b/CP2077 - EasyInstall/GitHub.cs
@@ -1,0 +1,161 @@
+namespace CP2077___EasyInstall
+{
+    using System;
+    using Newtonsoft.Json;
+
+    public partial class GitHub
+    {
+        [JsonProperty("url")]
+        public Uri Url { get; set; }
+
+        [JsonProperty("assets_url")]
+        public Uri AssetsUrl { get; set; }
+
+        [JsonProperty("upload_url")]
+        public string UploadUrl { get; set; }
+
+        [JsonProperty("html_url")]
+        public Uri HtmlUrl { get; set; }
+
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        [JsonProperty("author")]
+        public Author Author { get; set; }
+
+        [JsonProperty("node_id")]
+        public string NodeId { get; set; }
+
+        [JsonProperty("tag_name")]
+        public string TagName { get; set; }
+
+        [JsonProperty("target_commitish")]
+        public string TargetCommitish { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("draft")]
+        public bool Draft { get; set; }
+
+        [JsonProperty("prerelease")]
+        public bool Prerelease { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonProperty("published_at")]
+        public DateTimeOffset PublishedAt { get; set; }
+
+        [JsonProperty("assets")]
+        public Asset[] Assets { get; set; }
+
+        [JsonProperty("tarball_url")]
+        public Uri TarballUrl { get; set; }
+
+        [JsonProperty("zipball_url")]
+        public Uri ZipballUrl { get; set; }
+
+        [JsonProperty("body")]
+        public string Body { get; set; }
+    }
+
+    public partial class Asset
+    {
+        [JsonProperty("url")]
+        public Uri Url { get; set; }
+
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        [JsonProperty("node_id")]
+        public string NodeId { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("label")]
+        public object Label { get; set; }
+
+        [JsonProperty("uploader")]
+        public Author Uploader { get; set; }
+
+        [JsonProperty("content_type")]
+        public string ContentType { get; set; }
+
+        [JsonProperty("state")]
+        public string State { get; set; }
+
+        [JsonProperty("size")]
+        public long Size { get; set; }
+
+        [JsonProperty("download_count")]
+        public long DownloadCount { get; set; }
+
+        [JsonProperty("created_at")]
+        public DateTimeOffset CreatedAt { get; set; }
+
+        [JsonProperty("updated_at")]
+        public DateTimeOffset UpdatedAt { get; set; }
+
+        [JsonProperty("browser_download_url")]
+        public Uri BrowserDownloadUrl { get; set; }
+    }
+
+    public partial class Author
+    {
+        [JsonProperty("login")]
+        public string Login { get; set; }
+
+        [JsonProperty("id")]
+        public long Id { get; set; }
+
+        [JsonProperty("node_id")]
+        public string NodeId { get; set; }
+
+        [JsonProperty("avatar_url")]
+        public Uri AvatarUrl { get; set; }
+
+        [JsonProperty("gravatar_id")]
+        public string GravatarId { get; set; }
+
+        [JsonProperty("url")]
+        public Uri Url { get; set; }
+
+        [JsonProperty("html_url")]
+        public Uri HtmlUrl { get; set; }
+
+        [JsonProperty("followers_url")]
+        public Uri FollowersUrl { get; set; }
+
+        [JsonProperty("following_url")]
+        public string FollowingUrl { get; set; }
+
+        [JsonProperty("gists_url")]
+        public string GistsUrl { get; set; }
+
+        [JsonProperty("starred_url")]
+        public string StarredUrl { get; set; }
+
+        [JsonProperty("subscriptions_url")]
+        public Uri SubscriptionsUrl { get; set; }
+
+        [JsonProperty("organizations_url")]
+        public Uri OrganizationsUrl { get; set; }
+
+        [JsonProperty("repos_url")]
+        public Uri ReposUrl { get; set; }
+
+        [JsonProperty("events_url")]
+        public string EventsUrl { get; set; }
+
+        [JsonProperty("received_events_url")]
+        public Uri ReceivedEventsUrl { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        [JsonProperty("site_admin")]
+        public bool SiteAdmin { get; set; }
+    }
+}

--- a/CP2077 - EasyInstall/MainWindow.Designer.cs
+++ b/CP2077 - EasyInstall/MainWindow.Designer.cs
@@ -562,6 +562,7 @@ namespace CP2077___EasyInstall
             this.btnFindGoG.Name = "btnFindGoG";
             this.btnFindGoG.Size = new System.Drawing.Size(767, 30);
             this.btnFindGoG.TabIndex = 2;
+            this.btnFindGoG.Tag = "GOG";
             this.btnFindGoG.Text = "Automatic Detect GOG Path";
             this.btnFindGoG.Theme = MetroFramework.MetroThemeStyle.Light;
             this.tt_gog.SetToolTip(this.btnFindGoG, "Automatically Detect GOG Path");
@@ -574,6 +575,7 @@ namespace CP2077___EasyInstall
             this.btnFindSteam.Name = "btnFindSteam";
             this.btnFindSteam.Size = new System.Drawing.Size(767, 30);
             this.btnFindSteam.TabIndex = 1;
+            this.btnFindSteam.Tag = "Steam";
             this.btnFindSteam.Text = "Automatic Detect Steam Path";
             this.btnFindSteam.Theme = MetroFramework.MetroThemeStyle.Light;
             this.tt_steam.SetToolTip(this.btnFindSteam, "Automatically Detect Steam Path");

--- a/CP2077 - EasyInstall/MainWindow.cs
+++ b/CP2077 - EasyInstall/MainWindow.cs
@@ -30,16 +30,17 @@ namespace CP2077___EasyInstall
             InitializeComponent();
 
             CheckForUpdate();
+            _ = InitApplication();
+        }
+
+        private bool InitApplication()
+        {
             try
             {
-                // This whole initialisation of the program is really stupid.
-                // We shouldn't be starting the application with an exception
-                // to check if the user has already installed the mods.
-                // We need a better solution but I don't care for the time being.
-
                 if (GamePath == null)
                 {
-                    throw new ArgumentException();
+                    TraceDebugWrite("Patch not already installed!");
+                    return true;
                 }
 
                 // Check if the patch is already installed. If game_path file != NULL == already installed.
@@ -54,10 +55,12 @@ namespace CP2077___EasyInstall
 
                 LoadSettings(_generalPath);
                 TraceDebugWrite("Patch already installed!");
+                return true;
             }
-            catch (ArgumentException) // ArugmentException for not being able to read app settings.
+            catch (Exception ex)
             {
-                TraceDebugWrite("Patch not already installed!");
+                TraceDebugWrite($"Exception while checking for latest version: {ex}");
+                return true;
             }
         }
 

--- a/CP2077 - EasyInstall/MainWindow.cs
+++ b/CP2077 - EasyInstall/MainWindow.cs
@@ -42,7 +42,7 @@ namespace CP2077___EasyInstall
 
                 // Check if the patch is already installed. If game_path file != NULL == already installed.
                 TraceDebugWrite(GamePath);
-                _generalPath = Path.Combine(GamePath, "bin", "x64"); ;
+                _generalPath = Path.Combine(GamePath, "bin", "x64");
                 btnMain.Text = "Patch already installed!";
                 EnableGbx(); // Enable settings.
                 btnMain.Enabled = false;
@@ -109,11 +109,12 @@ namespace CP2077___EasyInstall
 
             try
             {
-                latestVersion = UpdateUtil.GetLatestApplicationVersion();
+                GitHub response = UpdateUtil.GetGitHubAPIInfo("LittleZen", "Cyberpunk2077-Patch-Easy-Installer");
+                latestVersion = !Version.TryParse(response.TagName.Remove(0, 1), out var latestGitHubVersion) ? null : latestGitHubVersion;
             }
             catch (Exception ex)
             {
-                Trace.WriteLine($"Exception while checking for latest version: {ex}");
+                TraceDebugWrite($"Exception while checking for latest version: {ex}");
                 return;
             }
 
@@ -253,8 +254,8 @@ namespace CP2077___EasyInstall
 
             try
             {
-                DownloadLatestVersion(); // create folder called "Patch"(inside patcher directory not CP folder) with all update inside. Function "PatchGame" will install everything from it
-                var release = UpdateUtil.GetLatestModRelease();
+                DownloadLatestVersion(); // Create folder called "Patch"(inside patcher directory not CP folder) with all update inside. Function "PatchGame" will install everything from it.
+                var release = UpdateUtil.GetGitHubAPIInfo("yamashi", "CyberEngineTweaks").Assets[0].Name;
                 TraceDebugWrite("Release name: ", release);
 
                 // Move files from patch to Cyberpunk 2077 path.
@@ -262,9 +263,6 @@ namespace CP2077___EasyInstall
                 TraceDebugWrite($"gamePath: {gamePath}");
                 Copy("Patch", gamePath);
                 SaveSettings();
-
-                //using (var outputFile = new StreamWriter(GamePath))
-                //    outputFile.Write(gamePath);
 
                 var configFile = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
                 var settings = configFile.AppSettings.Settings;
@@ -281,17 +279,12 @@ namespace CP2077___EasyInstall
 
                 TraceDebugWrite($"game_path path = {GamePath}");
 
-                // Write Path file. It is used for checking if the patch has already been installed (on next restart)
-                //File.WriteAllText(GamePath, gamePath);
-
-                TraceDebugWrite("Path correctly created!\n");
-
-                // Delete "Patch" working folder
+                // Delete "Patch" working folder.
                 var downloadPath = Path.Combine(CurrentDir, "Patch");
                 if (Directory.Exists(downloadPath))
                     Directory.Delete(downloadPath, true);
 
-                // Success + set-up interface
+                // Success + set-up interface.
                 MetroFramework.MetroMessageBox.Show(this, "Patch successfully installed!", "Success", MessageBoxButtons.OK, MessageBoxIcon.Question);
                 btnMain.Text = "Successfully Installed!";
                 btnMain.Enabled = false;
@@ -302,7 +295,7 @@ namespace CP2077___EasyInstall
             {
                 MetroFramework.MetroMessageBox.Show(this, $"Error during installation {ExceptionAsString(ex)}", "Critical Error!", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 btnMain.Text = "Critical Error!";
-                DisableGbx(); //disable the settings page
+                DisableGbx(); // Disable the settings page.
             }
         }
 
@@ -397,7 +390,7 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                var release = UpdateUtil.GetLatestModRelease(); // Downloaded zip name
+                var release = UpdateUtil.GetGitHubAPIInfo("yamashi", "CyberEngineTweaks").Assets[0].Name; // Downloaded zip name
                 var downloadPath = Path.Combine(CurrentDir, "Patch"); // Where temporary extract the file downloaded
                 var zipDownloadFile = Path.Combine(CurrentDir, $"{release}.zip"); // Yamashi's zip archive
 
@@ -454,7 +447,7 @@ namespace CP2077___EasyInstall
         {
             try
             {
-                PatchGame(File.ReadAllText(GamePath));
+                PatchGame(GamePath);
                 btnMain.Text = "Successfully Installed!";
             }
             catch (Exception ex)

--- a/CP2077 - EasyInstall/UpdateUtil.cs
+++ b/CP2077 - EasyInstall/UpdateUtil.cs
@@ -1,10 +1,8 @@
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
-using System.Text.RegularExpressions;
 
 namespace CP2077___EasyInstall
 {
@@ -38,34 +36,16 @@ namespace CP2077___EasyInstall
         }
 
         /// <summary>
-        /// Gets the latest version of Cyberpunk2077-Patch-Easy-Installer according to the Github API.
-        /// </summary>
-        /// <returns>A Version representing the latest available version of Cyberpunk2077-Patch-Easy-Installer, or null if the latest version could not be determined.</returns>
-        public static Version GetLatestApplicationVersion()
-        {
-            string responseJson = GetGitHubAPIDetails("LittleZen", "Cyberpunk2077-Patch-Easy-Installer");
-            if (string.IsNullOrEmpty(responseJson))
-                return null;
-
-            GitHub tagName = JsonConvert.DeserializeObject<GitHub>(responseJson);
-
-            return !Version.TryParse(tagName.TagName.Remove(0, 1), out var latestVersion) ? null : latestVersion;
-        }
-
-
-        /// <summary>
         /// Gets the latest version of CyberEngineTweaks according to the Github API.
         /// </summary>
         /// <returns>The filename of the release zip.</returns>
-        public static string GetLatestModRelease()
+        public static GitHub GetGitHubAPIInfo(string username, string repo)
         {
-            string responseJson = GetGitHubAPIDetails("yamashi", "CyberEngineTweaks");
+            string responseJson = GetGitHubAPIDetails(username, repo);
             if (string.IsNullOrEmpty(responseJson))
                 return null;
-            
-            GitHub releaseName = JsonConvert.DeserializeObject<GitHub>(responseJson);
 
-            return releaseName.Assets[0].Name;
+            return JsonConvert.DeserializeObject<GitHub>(responseJson);
         }
 
         private static string GetGitHubAPIDetails(string username, string repo) => GetStringFromURL($"https://api.github.com/repos/{username}/{repo}/releases/latest");

--- a/CP2077 - EasyInstall/packages.config
+++ b/CP2077 - EasyInstall/packages.config
@@ -1,6 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MetroModernUI" version="1.4.0.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
+  <package id="System.Configuration.ConfigurationManager" version="5.0.0" targetFramework="net472" />
   <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net472" />
+  <package id="System.Security.AccessControl" version="5.0.0" targetFramework="net472" />
+  <package id="System.Security.Permissions" version="5.0.0" targetFramework="net472" />
+  <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Ok, a decent number of changes here, but I feel they're needed.

- **Use app.config for storing game path and installed mod version:** Rather than using a separate file for game path, we should probably be using the app.config file that is used with .NET applications, so I'm using it for both the game path and the currently installed mod version.
- **Only download mods if new version is available:** It makes sense to only download the files if there is a new update, so I store the currently installed version and check it when the Check for Update button is clicked.
- **Updated settings storing:** There was an issue where the `config.json` wasn't being created properly when the mod was installed for the first time and could error out, this should be fixed now.
- **Refactored GitHub API calls:** Created a dedicated GitHub API class so that I could minimise the code for making calls to the GitHub API. Should also allow for future extensions if there are more API calls we need to make to GitHub.
- **Refactored Steam and GOG auto detect logic:** Since these methods were the same, I could improve this to prevent repetitive code.
- **Refactored application init to not start on an exception**: It never made sense to do it like this, doesn't look right. Using a discard since we don't really care about what the actual value returned is, just that the function says it's done.